### PR TITLE
Add an optional proxy for jupyterhub::node

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -252,8 +252,18 @@ class jupyterhub::reverse_proxy(String $domain_name) {
   }
 }
 
-class jupyterhub::node {
+class jupyterhub::node (
+  Optional[String] $http_proxy = undef,
+  Optional[String] $https_proxy = undef,
+) {
   include jupyterhub::base
+
+  if ($http_proxy != undef and $https_proxy != undef){
+    # Lets use a proxy for all the pip install
+    Exec {
+      environment => ["http_proxy=$http_proxy", "https_proxy=$https_proxy"],
+    }
+  }
 
   exec { 'pip_notebook':
     command => '/opt/jupyterhub/bin/pip install --no-cache-dir notebook',


### PR DESCRIPTION
This proxy can be used when the compute nodes does not have a direct internet connection. 