### PR TITLE
Support jupyter-rsession-proxy to launch RStudio-Server v2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,6 @@ To control options and traitlets of Jupyter Notebook and its extensions, use `ju
 jupyterhub::jupyter_notebook_config_hash:
   ServerProxy:
     servers:
-      rstudio:
-        command: ["rserver", "--www-port={port}", "--www-frame=same", "--www-address=127.0.0.1"]
-        timeout: 30
-        launcher_entry:
-          title: RStudio
       code-server:
         command: ["code-server", "--auth=none", "--disable-telemetry", "--host=127.0.0.1", "--port={port}"]
         timeout: 30

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -39,12 +39,6 @@ jupyterhub::jupyterhub_config_hash:
 jupyterhub::jupyter_notebook_config_hash:
   ServerProxy:
     servers:
-      rstudio:
-        command: ["rserver", "--www-address=127.0.0.1", "--www-port={port}", "--www-frame=same"]
-        timeout: 30
-        launcher_entry:
-          title: RStudio
-          enabled: false
       code-server:
         command: ["code-server", "--auth=none", "--disable-telemetry",  "--host=127.0.0.1", "--port={port}"]
         timeout: 30

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -69,6 +69,12 @@ class jupyterhub::node::install (Stdlib::Absolutepath $prefix) {
     require => Exec['pip_notebook']
   }
 
+  exec { 'pip_jupyter-rsession-proxy':
+    command => "${prefix}/bin/pip install --no-cache-dir git+https://github.com/ComputeCanada/jupyter-rsession-proxy@rstudio-server",
+    creates => "${prefix}/lib/python3.6/site-packages/jupyter_rsession_proxy/",
+    require => Exec['pip_jupyterlab']
+  }
+
   exec { 'pip_jupyter-desktop-server':
     command => "${prefix}/bin/pip install --no-cache-dir https://github.com/cmd-ntrf/jupyter-desktop-server/archive/cvmfs-mate.zip",
     creates => "${prefix}/lib/python3.6/site-packages/jupyter_desktop/",


### PR DESCRIPTION
Use forked jupyter-rsession-proxy that fixes : 
- `--set-data-dir` to temporary directory instead of the default `/var/run/rstudio` 
- support multiple rstudio-server versions, from `v1.2.1335` and up

Remove `rserver` command as the proxy handles the server launch.