### PR TITLE
add option to apply export values from hierdata to submit.sh.epp template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -268,6 +268,7 @@ class jupyterhub (
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
   $module_list = lookup('jupyterhub::kernel::module::list', Array[String], undef, [])
   $venv_prefix = lookup('jupyterhub::kernel::venv::prefix', String, undef, '/opt/ipython-kernel')
+  $submit_export = lookup('jupyterhub::submit::export', Hash[String, Any], undef, {})
   file { 'submit.sh':
     path    => '/etc/jupyterhub/submit.sh',
     content => epp('jupyterhub/submit.sh', {
@@ -276,6 +277,7 @@ class jupyterhub (
         'node_prefix'      => $node_prefix,
         'venv_prefix'      => $venv_prefix,
         'slurm_partitions' => join($slurm_partitions, ','),
+        'export_vals'      => $submit_export,
     }),
     mode    => '0644',
   }

--- a/templates/submit.sh.epp
+++ b/templates/submit.sh.epp
@@ -14,6 +14,7 @@
 #SBATCH --partition=<%= $slurm_partitions %>
 <% } %>
 
+<% if $export_vals == {} { %>
 unset XDG_RUNTIME_DIR
 
 # Disable variable export with sbatch
@@ -32,6 +33,11 @@ export PYTHONPATH=${PYTHONPATH}:"<%= $node_prefix %>/lib/usercustomize"
 # Jupyter core is trying to be smart with virtual environments
 # and it is not doing the right thing in our case.
 export JUPYTER_PREFER_ENV_PATH=0
+<% } %>
+
+<% $export_vals.each |$key, $value| { %>
+export <%= $key -%>=<%=$value -%>
+<% } %>
 
 {% if modules %}
 module load {{modules|join(' ')}}


### PR DESCRIPTION
- add option to apply export values from hierdata to the submit.sh.epp template with `jupyter::submit::export`
- use existing export values by default if no export values are provided in hierdata