### PR TITLE
ensure classes are run in order

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -1,11 +1,8 @@
 class jupyterhub::base(Stdlib::Absolutepath $prefix) {
-  class { 'jupyterhub::base::install::venv':
+  class { 'jupyterhub::base::install::packages': }
+  -> class { 'jupyterhub::base::install::venv':
     prefix => $prefix
   }
-
-  contain jupyterhub::base::install::packages
-  contain jupyterhub::base::install::venv
-  Class['jupyterhub::base::install::packages'] -> Class['jupyterhub::base::install::venv']
 }
 
 class jupyterhub::base::install::packages {


### PR DESCRIPTION
Fix for https://github.com/ComputeCanada/puppet-jupyterhub/issues/45.

This change ensures that `jupyterhub::base::install::packages` is run before `jupyterhub::base::install::venv`.