### PR TITLE
Move IPython history to memory

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -59,6 +59,8 @@ jupyterhub::jupyterhub_config_hash:
       def: 'lab'
 
 jupyterhub::jupyter_notebook_config_hash:
+  NotebookNotary:
+    db_file: ':memory:'
   Lmod:
     launcher_pins: ['desktop']
   ServerProxy:

--- a/files/ipython_config.py
+++ b/files/ipython_config.py
@@ -1,0 +1,4 @@
+c = get_config()  #noqa
+# Move IPython history to in-memory sqlite instead of on-disk.
+# This avoids kernel hanging issues with network filesystem like Lustre and NFS.
+c.HistoryAccessor.hist_file = ":memory:"

--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -40,7 +40,7 @@ class jupyterhub::kernel::venv (
   }
 
   file { "${prefix}/etc/ipython/ipython_config.py":
-    content => 'puppet:///modules/jupyterhub/ipython_config.py',
+    source => 'puppet:///modules/jupyterhub/ipython_config.py',
   }
 
   exec { 'install_kernel':

--- a/manifests/kernel.pp
+++ b/manifests/kernel.pp
@@ -29,6 +29,20 @@ class jupyterhub::kernel::venv (
     path    => ["${prefix}/bin"],
   }
 
+  file { "${prefix}/etc":
+    ensure  => directory,
+    require => Exec['kernel_venv'],
+  }
+
+  file { "${prefix}/etc/ipython":
+    ensure  => directory,
+    require => File["${prefix}/etc"],
+  }
+
+  file { "${prefix}/etc/ipython/ipython_config.py":
+    content => 'puppet:///modules/jupyterhub/ipython_config.py',
+  }
+
   exec { 'install_kernel':
     command => "python -m ipykernel install --name python3 --prefix ${::jupyterhub::node::prefix}",
     creates => "${::jupyterhub::node::prefix}/share/jupyter/kernels/python3/kernel.json",


### PR DESCRIPTION
Avoid issue with NFS and large parallel filesystem when initiating the history sqlite database.