### PR TITLE
Install ipywidgets and dependencies in the jupyterhub's environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ If the compute nodes cannot access Internet, configure the puppet agent to use
 | `jupyterhub::pammfauthenticator::url` | String |  Url to pammfauthenticator source code release file | refer to [data/common.yaml](data/common.yaml) |
 | `jupyterhub::jupyterhub_traefik_proxy::version` | String |  jupyterhub-traefik-proxy package version to install | refer to [data/common.yaml](data/common.yaml) |
 | `jupyterhub::nbgitpuller::version` | String | nbgitpuller package version to install | refer to [data/common.yaml](data/common.yaml) |
+| `jupyterhub::ipywidgets::version` | String | ipywidgets package version to install | refer to [data/common.yaml](data/common.yaml) |
+| `jupyterhub::widgetsnbextension::version` | String | widgetsnbextension package version to install | refer to [data/common.yaml](data/common.yaml) |
+| `jupyterhub::jupyterlab_widgets::version` | String | jupyterlab_widgets package version to install | refer to [data/common.yaml](data/common.yaml) |
 
 ### Hub options
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,6 +4,9 @@ jupyterhub::python3::version: "3.12"
 jupyterhub::kernel::venv::python: "3.12"
 
 jupyterhub::nbgitpuller::version: 1.2.1
+jupyterhub::ipywidgets::version: 8.1.5
+jupyterhub::widgetsnbextension::version: 4.0.13
+jupyterhub::jupyterlab_widgets::version: 3.0.13
 jupyterhub::notebook::version: 6.5.7
 jupyterhub::jupyterhub::version: 4.1.6
 jupyterhub::pamela::version: 1.2.0

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -21,6 +21,9 @@ class jupyterhub::node::install (
   $jupyterhub_version = lookup('jupyterhub::jupyterhub::version')
   $batchspawner_version = lookup('jupyterhub::batchspawner::version')
   $nbgitpuller_version = lookup('jupyterhub::nbgitpuller::version')
+  $ipywidgets_version = lookup('jupyterhub::ipywidgets::version')
+  $widgetsnbextension_version = lookup('jupyterhub::widgetsnbextension::version')
+  $jupyterlab_widgets_version = lookup('jupyterhub::jupyterlab_widgets::version')
   $notebook_version = lookup('jupyterhub::notebook::version')
   $jupyterlab_version = lookup('jupyterhub::jupyterlab::version')
   $jupyter_server_proxy_version = lookup('jupyterhub::jupyter_server_proxy::version')
@@ -36,6 +39,9 @@ class jupyterhub::node::install (
         'batchspawner_version'           => $batchspawner_version,
         'notebook_version'               => $notebook_version,
         'nbgitpuller_version'            => $nbgitpuller_version,
+        'ipywidgets_version'             => $ipywidgets_version,
+        'widgetsnbextension_version'     => $widgetsnbextension_version,
+        'jupyterlab_widgets_version'     => $jupyterlab_widgets_version,
         'jupyterlab_version'             => $jupyterlab_version,
         'jupyter_server_proxy_version'   => $jupyter_server_proxy_version,
         'jupyterlmod_version'            => $jupyterlmod_version,

--- a/templates/node-requirements.txt.epp
+++ b/templates/node-requirements.txt.epp
@@ -8,6 +8,9 @@ batchspawner==<%= $batchspawner_version %>
 <% if $jupyterlab_nvdashboard_version { %>jupyterlab-nvdashboard==<%= $jupyterlab_nvdashboard_version %><% } %>
 <% if $jupyterlmod_version { %>jupyterlmod==<%= $jupyterlmod_version %><% } %>
 <% if $nbgitpuller_version { %>nbgitpuller==<%= $nbgitpuller_version %><% } %>
+<% if $ipywidgets_version { %>ipywidgets==<%= $ipywidgets_version %><% } %>
+<% if $widgetsnbextension_version { %>widgetsnbextension==<%= $widgetsnbextension_version %><% } %>
+<% if $jupyterlab_widgets_version { %>jupyterlab_widgets==<%= $jupyterlab_widgets_version %><% } %>
 
 aiohappyeyeballs==2.4.3
 aiohttp==3.10.10


### PR DESCRIPTION
This is to allow for interactive features in notebooks such as
```import tqdm.notebook
import time

for i in tqdm.notebook.tqdm(range(10)):
  time.sleep(1)
``` 

or 
```
from ipywidgets import interact

def play_with(x=5):
    print(x)

interact(play_with, threshold=(0, 10, 1));
``` 

or interactive plots with plotly