### PR TITLE
When kernel::venv::prefix is redefined, the job script needs to source it.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,8 +175,9 @@ class jupyterhub (
   $node_prefix = lookup('jupyterhub::node::prefix', String, undef, $prefix)
   $jupyterhub_config_base = parsejson(file('jupyterhub/jupyterhub_config.json'))
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
+  $kernel_prefix = lookup('jupyterhub::kernel::venv::prefix', Stdlib::Absolutepath, undef, '/opt/ipython-kernel')
   $prologue = $kernel_setup ? {
-    'venv'   => 'export VIRTUAL_ENV_DISABLE_PROMPT=1; source /opt/ipython-kernel-computecanada/bin/activate',
+    'venv'   => "export VIRTUAL_ENV_DISABLE_PROMPT=1; source ${kernel_prefix}/bin/activate",
     'module' => '',
   }
   $jupyterhub_config_params = {


### PR DESCRIPTION
Otherwise jobs have a message such as
```
/var/spool/slurmd/job00008/slurm_script: line 37: /opt/ipython-kernel-computecanada/bin/activate: No such file or directory
``` 

in the logs. 