### PR TITLE
Split kernel's specs from node and graft through JUPYTER_PATH to allow node from CVMFS with the local kernel

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -179,9 +179,8 @@ class jupyterhub (
   $jupyterhub_config_base = parsejson(file('jupyterhub/jupyterhub_config.json'))
   $kernel_setup = lookup('jupyterhub::kernel::setup', Enum['venv', 'module'], undef, 'venv')
   $kernel_prefix = lookup('jupyterhub::kernel::venv::prefix', Stdlib::Absolutepath, undef, '/opt/ipython-kernel')
-  $kernel_paths = lookup('jupyterhub::kernel::venv::kernels_path', Stdlib::Absolutepath, undef, '/opt/jupyter_kernels')
   $prologue = $kernel_setup ? {
-    'venv'   => "export JUPYTER_PATH=${kernel_paths}:\$JUPYTER_PATH; export VIRTUAL_ENV_DISABLE_PROMPT=1; source ${kernel_prefix}/bin/activate",
+    'venv'   => "export JUPYTER_PATH=${kernel_prefix}/puppet-jupyter:\$JUPYTER_PATH; export VIRTUAL_ENV_DISABLE_PROMPT=1; source ${kernel_prefix}/bin/activate",
     'module' => '',
   }
   $jupyterhub_config_params = {


### PR DESCRIPTION
With the newest setup for jupyterhub_node, which we take from CVMFS, locally modified kernels with installed python packages no longer work. 

This PR splits the installation of kernels from that of the jupyter environment itself. 