### PR TITLE
Add jupyterlab_disabled_extensions parameter for extension lockdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,34 @@ puppet-jupyterhub installs the service [jupyterhub-announcement](https://github.
 | `jupyterhub::node::install::python` | String | Python version to be installed by uv | `%{alias('jupyterhub::python3::version')}` |
 | `jupyterhub::node::install::packages` | Array[String] | List of extra packages to install in the node virtual environment | `[]` |
 | `jupyterhub::node::install::frozen_deps` | Boolean | Install all unlisted dependencies versions as frozen by this module | `true` |
+| `jupyterhub::node::install::jupyterlab_disabled_extensions` | Array[String] | List of JupyterLab extensions or plugins to disable. When non-empty, the Extension Manager and Plugin Manager are also disabled. | `[]` |
+
+### Disabling JupyterLab Extensions
+
+To prevent users from using specific JupyterLab features (such as file download),
+you can disable individual extensions or plugins. When any extensions are disabled,
+the Extension Manager and Plugin Manager are also automatically disabled to prevent
+users from installing or re-enabling extensions.
+
+**Important**: Strongly consider setting `jupyterhub::disable_user_config` to
+`true` when using this feature. Otherwise users may be able to override disabled
+extensions via their personal Jupyter configuration.
+
+Example -- disable download functionality:
+```yaml
+jupyterhub::disable_user_config: true
+jupyterhub::node::install::jupyterlab_disabled_extensions:
+  - "@jupyterlab/filebrowser-extension:download"
+  - "@jupyterlab/filebrowser-extension:open-browser-tab"
+  - "@jupyterlab/docmanager-extension:download"
+  - "@jupyterlab/docmanager-extension:open-browser-tab"
+  - "@jupyterlab/notebook-extension:export"
+  - "@jupyterlab/collaboration-extension"
+```
+
+Values are JupyterLab extension or plugin identifiers. Disable an entire extension
+(e.g., `@jupyterlab/extensionmanager-extension`) or individual plugins within one
+(e.g., `@jupyterlab/filebrowser-extension:download`).
 
 ### Kernel options
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,6 +10,7 @@ jupyterhub::node::prefix: "/opt/jupyterhub_node"
 jupyterhub::node::config::jupyter_server_config: "%{alias('jupyterhub::jupyter_notebook_config_hash')}"
 jupyterhub::node::install_method: "venv"
 jupyterhub::node::install::python: "%{alias('jupyterhub::python3::version')}"
+jupyterhub::node::install::jupyterlab_disabled_extensions: []
 
 jupyterhub::kernel::install_method: venv
 jupyterhub::kernel::venv::prefix: "/opt/ipython_kernel"


### PR DESCRIPTION
Adds `jupyterhub::node::install::jupyterlab_disabled_extensions` parameter to disable specific JupyterLab extensions or plugins. When extensions are disabled, the Extension Manager and Plugin Manager are automatically disabled to prevent users from installing or re-enabling extensions.

Refactors page_config.json generation to support added functionality while maintaining backward compatibility with existing server-proxy configuration behavior in page_config.json .

Updated readme for added feature, as well as a note suggesting `jupyterhub::disable_user_config: true` to prevent attempted user overrides.